### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,5 +1,9 @@
 name: labels
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/alismx/alismx.github.io/security/code-scanning/1](https://github.com/alismx/alismx.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, it appears that the `contents: read` permission is sufficient for the `actions/checkout` step, and the `crazy-max/ghaction-github-labeler` action likely requires `contents: read` and `issues: write` permissions to manage labels. We will add these permissions explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
