### PR TITLE
fix: correct checkov blog post wording and nav labels

### DIFF
--- a/docs/blog/posts/2026/06/sast-iac-checkov.md
+++ b/docs/blog/posts/2026/06/sast-iac-checkov.md
@@ -34,7 +34,7 @@ pin: true
 
 # DevSecOps: Scan Infrastructure Code for Misconfigurations with Checkov
 
-Infrastructure code often passes syntax checks but contains security misconfigurations. Open buckets, unencrypted databases, overly permissive access policies. Checkov scans IaC files across 20+ formats for these patterns before you deploy.
+Infrastructure code contains security misconfigurations. Open buckets, unencrypted databases, overly permissive access policies. Checkov scans IaC files across 20+ formats for these patterns before you deploy.
 
 **TL;DR**: Install checkov, scan your IaC directory, configure your repository, and add it to your CI pipeline to catch infrastructure misconfigurations before they reach production.
 
@@ -171,7 +171,7 @@ SARIF integrates with GitHub Code Scanning and GitLab SAST which renders finding
 
 ## Add to CI/CD
 
-The `checkov-action` with the `github_failed_only` output format reports findings as inline checks on the pull request.
+The `checkov-action` with the `github_failed_only` output reports failures on the GitHub action page.
 
 ```yaml
 # .github/workflows/checkov.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,8 +7,8 @@ repo_name: alismx/alismx.github.io
 docs_dir: docs
 
 nav:
-  - alismx profile: index.md
-  - alismx posts:
+  - profile: index.md
+  - posts:
     - blog/index.md
 
 plugins:


### PR DESCRIPTION
## Summary
Minor wording fixes in the checkov blog post and simplified nav labels.

## Changes
- **sast-iac-checkov.md:** Removed "often passes syntax checks but" from intro (overstated), updated checkov-action description to be more accurate
- **mkdocs.yml:** Simplified nav labels — removed "alismx" prefix from profile and posts

## Why
- Clearer, more direct prose in the blog post
- Cleaner navigation labels

## Testing
- [ ] Site builds correctly

## Related
- PR #16 (merged)